### PR TITLE
Solve DNA

### DIFF
--- a/Lille Kat 2023_08/dna/dna.py
+++ b/Lille Kat 2023_08/dna/dna.py
@@ -1,0 +1,28 @@
+from sys import stdin
+
+N = int(next(stdin))
+s = next(stdin)
+
+flipped = False
+num_bs = 0
+mutations = 0
+
+for i in range(N, -1, -1):
+    c = s[i] if not flipped else ('A' if s[i] == 'B' else 'B')
+
+    if c == 'A' and num_bs > 0:
+        mutations += 1
+
+        if num_bs > 1:
+            flipped = not flipped
+            c = 'B'
+
+        num_bs = 0
+
+    if c == 'B':
+        num_bs += 1
+
+if num_bs > 0:
+    mutations += 1
+
+print(mutations)


### PR DESCRIPTION
We cracked the greedy solution 😎 

Going right to left, we have this basic idea: if we have `BBB`, it is *always* better to flip twice than it is to mutate all three `B`s into `A`s. And for `BB`, it is the same number of mutations to flip and to mutate each `BB`. Thus, we just count all `B`s until we hit an `A` and then perform a mutation each time.

Closes: #48